### PR TITLE
Small linux improvements

### DIFF
--- a/lib/disks.js
+++ b/lib/disks.js
@@ -33,6 +33,21 @@ exports.drives = function (callback) {
 };
 
 /**
+ * Filter for retrieved disks list
+ *
+ * @param value
+ * @param index
+ * @param array
+ * @return {boolean}
+ */
+function drivesFilter(value, index, array){
+   return (
+	   array.indexOf(value) === index &&                 // Removes duplicate entries (e.g. filter btrfs subvolumes)
+      ['none', 'devtmpfs', 'tmpfs'].indexOf(value) < 0  // Removes ram drives and tmp filesystems
+   );
+}
+
+/**
  * Execute a command to retrieve disks list.
  *
  * @param command
@@ -48,8 +63,7 @@ function getDrives(command, callback) {
             drives.splice(0, 1);
             drives.splice(-1, 1);
 
-            // Removes ram drives
-            drives = drives.filter(function(item){ return item != 'none';});
+            drives = drives.filter(drivesFilter);
             callback(null, drives);
         }
     );
@@ -159,6 +173,13 @@ function detail(drive, callback) {
                     default:
                         getDetailNaN('df -P | grep ' + drive + ' | grep -oh \' /.*\'', function(e, d){
                             if (d) d = d.trim();
+
+                            // check for multiple mountpoints (e.g. btrfs subvolumes) and return them eventually as array
+                            var multiple = d.split('\n');
+                            if (multiple.length > 1) {
+                               d = multiple;
+                            }
+
                             callback(e, d);
                         });
                 }

--- a/lib/disks.js
+++ b/lib/disks.js
@@ -175,7 +175,7 @@ function detail(drive, callback) {
                             if (d) d = d.trim();
 
                             // check for multiple mountpoints (e.g. btrfs subvolumes) and return them eventually as array
-                            var multiple = d.split('\n');
+                            var multiple = d.split(/\s*\n\s*/);
                             if (multiple.length > 1) {
                                d = multiple;
                             }

--- a/lib/disks.js
+++ b/lib/disks.js
@@ -174,10 +174,10 @@ function detail(drive, callback) {
                         getDetailNaN('df -P | grep ' + drive + ' | grep -oh \' /.*\'', function(e, d){
                             if (d) d = d.trim();
 
-                            // check for multiple mountpoints (e.g. btrfs subvolumes) and return them eventually as array
+                            // check for multiple mountpoints (e.g. btrfs subvolumes) and return first one (which should be main volume moutpint).
                             var multiple = d.split(/\s*\n\s*/);
                             if (multiple.length > 1) {
-                               d = multiple;
+                               d = multiple[0];
                             }
 
                             callback(e, d);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "volumes",
     "harddisk"
   ],
-  "main": "./lib/disks",
   "dependencies": {
     "async": "~0.2.9",
     "numeral": "~1.4.8"


### PR DESCRIPTION
Improve output on some Linux systems. Most of the change is better handling for volumes with multiple mountpoins (e.g. btrfs subvolumes).

 * if volume have multiple mountpoints (e.g. btrfs subvolumes):
   * return it only once in drives() result
   * detail for such drive will contain array of mountpoins in mountpoint key
 * filter tmp filesystems

Before and after example output:
```json
[
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "12.57 MB",
    "available": "143.25 MB",
    "mountpoint": "/boot/efi",
    "volumename": "efi",
    "freePer": 91.93051064149809,
    "usedPer": 8.069489358501917,
    "total": "155.82 MB",
    "drive": "/dev/sda1"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "213.95 GB",
    "available": "701.12 GB",
    "mountpoint": "/home",
    "volumename": "home",
    "freePer": 76.61952967657459,
    "usedPer": 23.38047032342542,
    "total": "915.06 GB",
    "drive": "/dev/sdb2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "86.47 GB",
    "available": "31.82 GB",
    "mountpoint": "/\n /var/lib/pgsql\n /var/lib/mailman\n /usr/local\n /var/lib/mariadb\n /var/tmp\n /boot/grub2/x86_64-efi\n /opt\n /var/lib/libvirt/images\n /var/opt\n /tmp\n /srv\n /var/cache\n /var/lib/named\n /var/lib/mysql\n /var/crash\n /.snapshots\n /var/lib/machines\n /var/log\n /boot/grub2/i386-pc\n /var/spool",
    "volumename": "spool",
    "freePer": 26.89865225084287,
    "usedPer": 73.10134774915713,
    "total": "118.29 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "4.32 GB",
    "available": "0.00 ",
    "mountpoint": "/run/media/dosi/iTutor",
    "volumename": "iTutor",
    "freePer": 0,
    "usedPer": 100,
    "total": "4.32 GB",
    "drive": "/dev/sr0"
  }
]
```

```json
[
  {
    "used": "86.49 GB",
    "available": "31.80 GB",
    "mountpoint": [
      "/",
      "/var/lib/pgsql",
      "/var/lib/mailman",
      "/usr/local",
      "/var/lib/mariadb",
      "/var/tmp",
      "/boot/grub2/x86_64-efi",
      "/opt",
      "/var/lib/libvirt/images",
      "/var/opt",
      "/tmp",
      "/srv",
      "/var/cache",
      "/var/lib/named",
      "/var/lib/mysql",
      "/var/crash",
      "/.snapshots",
      "/var/lib/machines",
      "/var/log",
      "/boot/grub2/i386-pc",
      "/var/spool"
    ],
    "volumename": "spool",
    "freePer": 26.88383430768721,
    "usedPer": 73.11616569231279,
    "total": "118.30 GB",
    "drive": "/dev/sda2"
  },
  {
    "used": "12.57 MB",
    "available": "143.25 MB",
    "mountpoint": "/boot/efi",
    "volumename": "efi",
    "freePer": 91.93051064149809,
    "usedPer": 8.069489358501917,
    "total": "155.82 MB",
    "drive": "/dev/sda1"
  },
  {
    "used": "214.01 GB",
    "available": "701.05 GB",
    "mountpoint": "/home",
    "volumename": "home",
    "freePer": 76.61265076906298,
    "usedPer": 23.387349230937016,
    "total": "915.06 GB",
    "drive": "/dev/sdb2"
  },
  {
    "used": "4.32 GB",
    "available": "0.00 ",
    "mountpoint": "/run/media/dosi/iTutor",
    "volumename": "iTutor",
    "freePer": 0,
    "usedPer": 100,
    "total": "4.32 GB",
    "drive": "/dev/sr0"
  }
]
```